### PR TITLE
Modify build-fastapi Workflow to Push Docker Image to GitHub Container Registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: false
+          push: true
           tags: |
             ghcr.io/${{ env.REPO_NAME }}/fastapi:latest
             ghcr.io/${{ env.REPO_NAME }}/fastapi:${{ github.sha }}


### PR DESCRIPTION
Fixes #1

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FabianSchurig/promptflow-starter-template/pull/2?shareId=5d3aec48-a302-48b7-9225-fe8e34d000c4).