### PR TITLE
Refactor Dockerfile with build and publish stages and add pull request workflow for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,23 @@ jobs:
             PACKAGE_VERSION=${{ env.PACKAGE_VERSION }}
           target: build
 
+      - name: Publish Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ env.REPO_NAME }}/publish:latest
+            ghcr.io/${{ env.REPO_NAME }}/publish:${{ github.sha }}
+          file: Dockerfile
+          build-args: |
+            REPO_URL=${{ secrets.PYPI_REPOSITORY_URL }}
+            REPO_USERNAME=${{ secrets.PYPI_USERNAME }}
+            REPO_PASSWORD=${{ secrets.PYPI_PASSWORD }}
+            PYPI_API_TOKEN=${{ secrets.PYPI_API_TOKEN }}
+            PACKAGE_VERSION=${{ env.PACKAGE_VERSION }}
+          target: publish
+
   build-fastapi:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,61 @@
+name: Pull Request Workflow
+
+on:
+  pull_request:
+    branches-ignore:
+      - main
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set repository name to lowercase
+        run: echo "REPO_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Extract package version
+        id: extract_version
+        run: echo "PACKAGE_VERSION=$(grep -oP '(?<=version = \")[^\"]*' pyproject.toml)" >> $GITHUB_ENV
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: |
+            ghcr.io/${{ env.REPO_NAME }}/build:latest
+            ghcr.io/${{ env.REPO_NAME }}/build:${{ github.sha }}
+          file: Dockerfile
+          build-args: |
+            REPO_URL=${{ secrets.PYPI_REPOSITORY_URL }}
+            REPO_USERNAME=${{ secrets.PYPI_USERNAME }}
+            REPO_PASSWORD=${{ secrets.PYPI_PASSWORD }}
+            PYPI_API_TOKEN=${{ secrets.PYPI_API_TOKEN }}
+            PACKAGE_VERSION=${{ env.PACKAGE_VERSION }}
+          target: build
+
+      - name: Run tests with docker build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          tags: |
+            ghcr.io/${{ env.REPO_NAME }}/test:latest
+            ghcr.io/${{ env.REPO_NAME }}/test:${{ github.sha }}
+          file: Dockerfile
+          build-args: |
+            REPO_URL=${{ secrets.PYPI_REPOSITORY_URL }}
+            REPO_USERNAME=${{ secrets.PYPI_USERNAME }}
+            REPO_PASSWORD=${{ secrets.PYPI_PASSWORD }}
+            PYPI_API_TOKEN=${{ secrets.PYPI_API_TOKEN }}
+            PACKAGE_VERSION=${{ env.PACKAGE_VERSION }}
+          target: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,12 @@ ARG REPO_PASSWORD=""
 ARG PYPI_API_TOKEN=""
 ARG PACKAGE_VERSION=""
 
-# Extract version from pyproject.toml and set it as PACKAGE_VERSION
-RUN PACKAGE_VERSION=$(grep -oP '(?<=version = ")[^"]*' pyproject.toml)
-
 # Copy project files
 COPY . /app
 WORKDIR /app
+
+# Extract version from pyproject.toml and set it as PACKAGE_VERSION
+RUN PACKAGE_VERSION=$(grep -oP '(?<=version = ")[^"]*' pyproject.toml)
 
 # Install dependencies and build the package
 RUN poetry install --no-root \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,13 @@ RUN if [ -z "$REPO_URL" ]; then \
     && poetry config http-basic.my-repo $REPO_USERNAME $REPO_PASSWORD; \
     fi
 
+FROM build as test
+
+# Run tests
+RUN poetry run pytest
+
+FROM build as publish
+
 # Publish the package (assuming you have configured the repository in pyproject.toml)
 RUN if [ -z "$REPO_URL" ]; then \
     if ! curl --silent --fail https://pypi.org/project/promptflow-starter-template/$PACKAGE_VERSION/ > /dev/null; then \


### PR DESCRIPTION
Fixes #5

Refactor the Dockerfile and add a pull request workflow for testing.

* **Dockerfile**:
  - Rename the existing stage to `publish`.
  - Add separate `build`, `test`, and `publish` stages.
  - Add a multi-stage step for tests.
  - Add the poetry build step.

* **.github/workflows/pull_request.yml**:
  - Add a new GitHub Actions workflow for pull requests.
  - Trigger the workflow on pull requests and commits not on the `main` branch.
  - Build the application using the `build` stage from the Dockerfile.
  - Run tests using the new `test` stage.

* **.github/workflows/build.yml**:
  - Refactor the workflow to use the new `publish` stage.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FabianSchurig/promptflow-starter-template/pull/6?shareId=29ce89fa-86b4-4790-a166-e6ecb5637741).