### PR TITLE
Fix publish step to skip if package version already exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.12-slim AS builder
 # Install Poetry via pip
 RUN pip install poetry
 
+# Install curl
+RUN apt-get update && apt-get install -y curl
+
 FROM builder AS build
 
 # Copy project files


### PR DESCRIPTION
Fixes #11

Install `curl` in the `Dockerfile` to ensure the check for the package version on PyPI works correctly.

* Add `RUN apt-get update && apt-get install -y curl` to install `curl` before the check for the package version.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FabianSchurig/promptflow-starter-template/pull/12?shareId=ed066c80-bc4b-4dc2-8f51-2421528462fb).